### PR TITLE
Replaced render_to_response with render

### DIFF
--- a/appendixG.rst
+++ b/appendixG.rst
@@ -463,7 +463,7 @@ Here's an example::
             p = Poll.objects.get(pk=poll_id)
         except Poll.DoesNotExist:
             raise Http404
-        return render_to_response('polls/detail.html', {'poll': p})
+        return render(request, 'polls/detail.html', {'poll': p})
 
 In order to use the ``Http404`` exception to its fullest, you should create a
 template that is displayed when a 404 error is raised. This template should be

--- a/chapter01.rst
+++ b/chapter01.rst
@@ -132,12 +132,12 @@ an HTML template (``latest_books.html``)::
 
     # views.py (the business logic)
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     from models import Book
 
     def latest_books(request):
         book_list = Book.objects.order_by('-pub_date')[:10]
-        return render_to_response('latest_books.html', {'book_list': book_list})
+        return render(request, 'latest_books.html', {'book_list': book_list})
 
 
     # urls.py (the URL configuration)

--- a/chapter04.rst
+++ b/chapter04.rst
@@ -1252,7 +1252,7 @@ directory using the following template code::
 Refresh the page in your Web browser, and you should see the fully rendered
 page.
 
-render_to_response()
+render()
 --------------------
 
 We've shown you how to load a template, fill a ``Context`` and return an
@@ -1263,39 +1263,39 @@ things. Because this is such a common idiom, Django provides a shortcut that
 lets you load a template, render it and return an ``HttpResponse`` -- all in
 one line of code.
 
-This shortcut is a function called ``render_to_response()``, which lives in the
+This shortcut is a function called ``render()``, which lives in the
 module ``django.shortcuts``. Most of the time, you'll be using
-``render_to_response()`` rather than loading templates and creating ``Context``
+``render()`` rather than loading templates and creating ``Context``
 and ``HttpResponse`` objects manually -- unless your employer judges your work
 by total lines of code written, that is.
 
 Here's the ongoing ``current_datetime`` example rewritten to use
-``render_to_response()``::
+``render()``::
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     import datetime
 
     def current_datetime(request):
         now = datetime.datetime.now()
-        return render_to_response('current_datetime.html', {'current_date': now})
+        return render(request, 'current_datetime.html', {'current_date': now})
 
 What a difference! Let's step through the code changes:
 
 * We no longer have to import ``get_template``, ``Template``, ``Context``,
   or ``HttpResponse``. Instead, we import
-  ``django.shortcuts.render_to_response``. The ``import datetime`` remains.
+  ``django.shortcuts.render``. The ``import datetime`` remains.
 
 * Within the ``current_datetime`` function, we still calculate ``now``, but
   the template loading, context creation, template rendering, and
   ``HttpResponse`` creation are all taken care of by the
-  ``render_to_response()`` call. Because ``render_to_response()`` returns
+  ``render()`` call. Because ``render()`` returns
   an ``HttpResponse`` object, we can simply ``return`` that value in the
   view.
 
-The first argument to ``render_to_response()`` is the name of the template to
-use. The second argument, if given, should be a dictionary to use in creating a
-``Context`` for that template. If you don't provide a second argument,
-``render_to_response()`` will use an empty dictionary.
+The first argument to ``render()`` is the request, the second is the name of
+the template to use. The third argument, if given, should be a dictionary to
+use in creating a ``Context`` for that template. If you don't provide a third
+argument, ``render()`` will use an empty dictionary.
 
 Subdirectories in get_template()
 --------------------------------
@@ -1312,11 +1312,11 @@ the subdirectory name and a slash before the template name, like so::
 
     t = get_template('dateapp/current_datetime.html')
 
-Because ``render_to_response()`` is a small wrapper around ``get_template()``,
-you can do the same thing with the first argument to ``render_to_response()``,
+Because ``render()`` is a small wrapper around ``get_template()``,
+you can do the same thing with the second argument to ``render()``,
 like this::
 
-    return render_to_response('dateapp/current_datetime.html', {'current_date': now})
+    return render(request, 'dateapp/current_datetime.html', {'current_date': now})
 
 There's no limit to the depth of your subdirectory tree. Feel free to use
 as many subdirectories as you like.

--- a/chapter04.rst
+++ b/chapter04.rst
@@ -1253,7 +1253,7 @@ Refresh the page in your Web browser, and you should see the fully rendered
 page.
 
 render()
---------------------
+--------
 
 We've shown you how to load a template, fill a ``Context`` and return an
 ``HttpResponse`` object with the result of the rendered template. We've

--- a/chapter05.rst
+++ b/chapter05.rst
@@ -41,7 +41,7 @@ In this example view, we use the ``MySQLdb`` library (available via
 http://www.djangoproject.com/r/python-mysql/) to connect to a MySQL database,
 retrieve some records, and feed them to a template for display as a Web page::
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     import MySQLdb
 
     def book_list(request):
@@ -50,7 +50,7 @@ retrieve some records, and feed them to a template for display as a Web page::
         cursor.execute('SELECT name FROM books ORDER BY name')
         names = [row[0] for row in cursor.fetchall()]
         db.close()
-        return render_to_response('book_list.html', {'names': names})
+        return render(request, 'book_list.html', {'names': names})
 
 .. SL Tested ok
 
@@ -77,12 +77,12 @@ As you might expect, Django's database layer aims to solve these problems.
 Here's a sneak preview of how the previous view can be rewritten using Django's
 database API::
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     from mysite.books.models import Book
 
     def book_list(request):
         books = Book.objects.order_by('name')
-        return render_to_response('book_list.html', {'books': books})
+        return render(request, 'book_list.html', {'books': books})
 
 We'll explain this code a little later in the chapter. For now, just get a
 feel for how it looks.

--- a/chapter07.rst
+++ b/chapter07.rst
@@ -162,10 +162,10 @@ Generally, there are two parts to developing a form: the HTML user interface
 and the backend view code that processes the submitted data. The first part is
 easy; let's just set up a view that displays a search form::
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
 
     def search_form(request):
-        return render_to_response('search_form.html')
+        return render(request, 'search_form.html')
 
 As we learned in Chapter 3, this view can live anywhere on your Python path.
 For sake of argument, put it in ``books/views.py``.
@@ -278,14 +278,14 @@ Now that we've verified ``request.GET`` is being passed in properly, let's hook
 the user's search query into our book database (again, in ``views.py``)::
 
     from django.http import HttpResponse
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     from mysite.books.models import Book
 
     def search(request):
         if 'q' in request.GET and request.GET['q']:
             q = request.GET['q']
             books = Book.objects.filter(title__icontains=q)
-            return render_to_response('search_results.html',
+            return render(request, 'search_results.html',
                 {'books': books, 'query': q})
         else:
             return HttpResponse('Please submit a search term.')
@@ -349,20 +349,20 @@ render the template again, like this:
 .. parsed-literal::
 
     from django.http import HttpResponse
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     from mysite.books.models import Book
 
     def search_form(request):
-        return render_to_response('search_form.html')
+        return render(request, 'search_form.html')
 
     def search(request):
         if 'q' in request.GET and request.GET['q']:
             q = request.GET['q']
             books = Book.objects.filter(title__icontains=q)
-            return render_to_response('search_results.html',
+            return render(request, 'search_results.html',
                 {'books': books, 'query': q})
         else:
-            **return render_to_response('search_form.html', {'error': True})**
+            **return render(request, 'search_form.html', {'error': True})**
 
 (Note that we've included ``search_form()`` here so you can see both views in
 one place.)
@@ -411,9 +411,9 @@ parameters::
                 error = True
             else:
                 books = Book.objects.filter(title__icontains=q)
-                return render_to_response('search_results.html',
+                return render(request, 'search_results.html',
                     {'books': books, 'query': q})
-        return render_to_response('search_form.html',
+        return render(request, 'search_form.html',
             {'error': error})
 
 .. SL Tested ok
@@ -487,9 +487,9 @@ like this:
                 **error = True**
             else:
                 books = Book.objects.filter(title__icontains=q)
-                return render_to_response('search_results.html',
+                return render(request, 'search_results.html',
                     {'books': books, 'query': q})
-        return render_to_response('search_form.html',
+        return render(request, 'search_form.html',
             {'error': error})
 
 Now, if you try submitting a search query greater than 20 characters long,
@@ -537,9 +537,9 @@ how we might fix that:
                 **errors.append('Please enter at most 20 characters.')**
             else:
                 books = Book.objects.filter(title__icontains=q)
-                return render_to_response('search_results.html',
+                return render(request, 'search_results.html',
                     {'books': books, 'query': q})
-        return render_to_response('search_form.html',
+        return render(request, 'search_form.html',
             {**'errors': errors**})
 
 Then, we need make a small tweak to the ``search_form.html`` template to
@@ -623,7 +623,7 @@ this::
 
     from django.core.mail import send_mail
     from django.http import HttpResponseRedirect
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
 
     def contact(request):
         errors = []
@@ -642,7 +642,7 @@ this::
                     ['siteowner@example.com'],
                 )
                 return HttpResponseRedirect('/contact/thanks/')
-        return render_to_response('contact_form.html',
+        return render(request, 'contact_form.html',
             {'errors': errors})
 
 .. SL Tested ok (modulo email config and lack of thanks view)
@@ -696,7 +696,7 @@ A couple of new things are happening here:
   ``HttpResponseRedirect`` object. We'll leave the implementation of that
   "success" page up to you (it's a simple view/URLconf/template), but we
   should explain why we initiate a redirect instead of, for example, simply
-  calling ``render_to_response()`` with a template right there.
+  calling ``render()`` with a template right there.
 
   The reason: if a user hits "Refresh" on a page that was loaded via
   ``POST``, that request will be repeated. This can often lead to undesired
@@ -740,7 +740,7 @@ edit each HTML field to insert the proper value in the proper place:
                     ['siteowner@example.com'],
                 )
                 return HttpResponseRedirect('/contact/thanks/')
-        return render_to_response('contact_form.html', {
+        return render(request, 'contact_form.html', {
             'errors': errors,
             **'subject': request.POST.get('subject', ''),**
             **'message': request.POST.get('message', ''),**
@@ -957,7 +957,7 @@ Here's how we can rewrite ``contact()`` to use the forms framework::
 
     # views.py
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     from mysite.contact.forms import ContactForm
 
     def contact(request):
@@ -974,7 +974,7 @@ Here's how we can rewrite ``contact()`` to use the forms framework::
                 return HttpResponseRedirect('/contact/thanks/')
         else:
             form = ContactForm()
-        return render_to_response('contact_form.html', {'form': form})
+        return render(request, 'contact_form.html', {'form': form})
 
     # contact_form.html
 
@@ -1081,7 +1081,7 @@ hurt.) To do this, we can use the ``initial`` argument when we create a
             form = ContactForm(
                 **initial={'subject': 'I love your site!'}**
             )
-        return render_to_response('contact_form.html', {'form': form})
+        return render(request, 'contact_form.html', {'form': form})
 
 .. SL Tested ok
 

--- a/chapter08.rst
+++ b/chapter08.rst
@@ -320,16 +320,16 @@ contents are identical except for the template they use::
 
     # views.py
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     from mysite.models import MyModel
 
     def foo_view(request):
         m_list = MyModel.objects.filter(is_new=True)
-        return render_to_response('template1.html', {'m_list': m_list})
+        return render(request, 'template1.html', {'m_list': m_list})
 
     def bar_view(request):
         m_list = MyModel.objects.filter(is_new=True)
-        return render_to_response('template2.html', {'m_list': m_list})
+        return render(request, 'template2.html', {'m_list': m_list})
 
 We're repeating ourselves in this code, and that's inelegant. At first, you
 may think to remove the redundancy by using the same view for both URLs,
@@ -348,7 +348,7 @@ the view to determine the template, like so::
 
     # views.py
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     from mysite.models import MyModel
 
     def foobar_view(request, url):
@@ -357,7 +357,7 @@ the view to determine the template, like so::
             template_name = 'template1.html'
         elif url == 'bar':
             template_name = 'template2.html'
-        return render_to_response(template_name, {'m_list': m_list})
+        return render(request, template_name, {'m_list': m_list})
 
 The problem with that solution, though, is that it couples your URLs to your
 code. If you decide to rename ``/foo/`` to ``/fooey/``, you'll have to remember
@@ -381,12 +381,12 @@ With this in mind, we can rewrite our ongoing example like this::
 
     # views.py
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     from mysite.models import MyModel
 
     def foobar_view(request, template_name):
         m_list = MyModel.objects.filter(is_new=True)
-        return render_to_response(template_name, {'m_list': m_list})
+        return render(request, template_name, {'m_list': m_list})
 
 As you can see, the URLconf in this example specifies ``template_name`` in the
 URLconf. The view function treats it as just another parameter.
@@ -487,16 +487,16 @@ Take this code, for example::
 
     # views.py
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     from mysite.models import Event, BlogEntry
 
     def event_list(request):
         obj_list = Event.objects.all()
-        return render_to_response('mysite/event_list.html', {'event_list': obj_list})
+        return render(request, 'mysite/event_list.html', {'event_list': obj_list})
 
     def entry_list(request):
         obj_list = BlogEntry.objects.all()
-        return render_to_response('mysite/blogentry_list.html', {'entry_list': obj_list})
+        return render(request, 'mysite/blogentry_list.html', {'entry_list': obj_list})
 
 The two views do essentially the same thing: they display a list of objects. So
 let's factor out the type of object they're displaying::
@@ -513,12 +513,12 @@ let's factor out the type of object they're displaying::
 
     # views.py
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
 
     def object_list(request, model):
         obj_list = model.objects.all()
         template_name = 'mysite/%s_list.html' % model.__name__.lower()
-        return render_to_response(template_name, {'object_list': obj_list})
+        return render(request, template_name, {'object_list': obj_list})
 
 With those small changes, we suddenly have a reusable, model-agnostic view!
 From now on, anytime we need a view that lists a set of objects, we can simply
@@ -562,7 +562,7 @@ A common bit of an application to make configurable is the template name::
 
     def my_view(request, template_name):
         var = do_something()
-        return render_to_response(template_name, {'var': var})
+        return render(request, template_name, {'var': var})
 
 Understanding Precedence of Captured Values vs. Extra Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -633,7 +633,7 @@ value for ``template_name``::
 
     def my_view(request, template_name='mysite/my_view.html'):
         var = do_something()
-        return render_to_response(template_name, {'var': var})
+        return render(request, template_name, {'var': var})
 
 .. SL Again wonder whether default should be unicode?
 
@@ -774,7 +774,7 @@ might build a nice way of doing that. Consider this URLconf/view layout::
     # views.py
 
     from django.http import Http404, HttpResponseRedirect
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
 
     def some_page(request):
         if request.method == 'POST':
@@ -782,7 +782,7 @@ might build a nice way of doing that. Consider this URLconf/view layout::
             return HttpResponseRedirect('/someurl/')
         elif request.method == 'GET':
             do_something_for_get()
-            return render_to_response('page.html')
+            return render(request, 'page.html')
         else:
             raise Http404()
 
@@ -800,7 +800,7 @@ this technique could help simplify our ``some_page()`` view::
     # views.py
 
     from django.http import Http404, HttpResponseRedirect
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
 
     def method_splitter(request, GET=None, POST=None):
         if request.method == 'GET' and GET is not None:
@@ -812,7 +812,7 @@ this technique could help simplify our ``some_page()`` view::
     def some_page_get(request):
         assert request.method == 'GET'
         do_something_for_get()
-        return render_to_response('page.html')
+        return render(request, 'page.html')
 
     def some_page_post(request):
         assert request.method == 'POST'
@@ -929,19 +929,19 @@ example::
         if not request.user.is_authenticated():
             return HttpResponseRedirect('/accounts/login/')
         # ...
-        return render_to_response('template1.html')
+        return render(request, 'template1.html')
 
     def my_view2(request):
         if not request.user.is_authenticated():
             return HttpResponseRedirect('/accounts/login/')
         # ...
-        return render_to_response('template2.html')
+        return render(request, 'template2.html')
 
     def my_view3(request):
         if not request.user.is_authenticated():
             return HttpResponseRedirect('/accounts/login/')
         # ...
-        return render_to_response('template3.html')
+        return render(request, 'template3.html')
 
 Here, each view starts by checking that ``request.user`` is authenticated
 -- that is, the current user has successfully logged into the site -- and

--- a/chapter09.rst
+++ b/chapter09.rst
@@ -62,12 +62,14 @@ simplicity.
 RequestContext and Context Processors
 =====================================
 
-When rendering a template, you need a context. Usually this is an instance of
-``django.template.Context``, but Django also comes with a special subclass,
+When rendering a template, you need a context. This can be an instance of
+``django.template.Context``, but Django also comes with a subclass,
 ``django.template.RequestContext``, that acts slightly differently.
 ``RequestContext`` adds a bunch of variables to your template context by
 default -- things like the ``HttpRequest`` object or information about the
-currently logged-in user.
+currently logged-in user. The ``render()`` shortcut creates a ``RequestContext`` 
+unless it is passed a different context instance explicitly.
+
 
 Use ``RequestContext`` when you don't want to have to specify the same set of
 variables in a series of templates. For example, consider these two views::
@@ -96,7 +98,7 @@ variables in a series of templates. For example, consider these two views::
         })
         return t.render(c)
 
-(Note that we're deliberately *not* using the ``render_to_response()`` shortcut
+(Note that we're deliberately *not* using the ``render()`` shortcut
 in these examples -- we're manually loading the templates, constructing the
 context objects and rendering the templates. We're "spelling out" all of the
 steps for the purpose of clarity.)
@@ -108,7 +110,7 @@ redundancy?
 ``RequestContext`` and **context processors** were created to solve this
 problem. Context processors let you specify a number of variables that get set
 in each context automatically -- without you having to specify the variables in
-each ``render_to_response()`` call. The catch is that you have to use
+each ``render()`` call. The catch is that you have to use
 ``RequestContext`` instead of ``Context`` when you render a template.
 
 The most low-level way of using context processors is to create some processors
@@ -161,15 +163,15 @@ Let's step through this code:
   variables it might need. In this example, the ``message`` template
   variable is set differently in each view.
 
-In Chapter 4, we introduced the ``render_to_response()`` shortcut, which saves
+In Chapter 4, we introduced the ``render()`` shortcut, which saves
 you from having to call ``loader.get_template()``, then create a ``Context``,
 then call the ``render()`` method on the template. In order to demonstrate the
 lower-level workings of context processors, the above examples didn't use
-``render_to_response()``, . But it's possible -- and preferable -- to use
-context processors with ``render_to_response()``. Do this with the
+``render()``, . But it's possible -- and preferable -- to use
+context processors with ``render()``. Do this with the
 ``context_instance`` argument, like so::
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
     from django.template import RequestContext
 
     def custom_proc(request):
@@ -182,13 +184,13 @@ context processors with ``render_to_response()``. Do this with the
 
     def view_1(request):
         # ...
-        return render_to_response('template1.html',
+        return render(request, 'template1.html',
             {'message': 'I am view 1.'},
             context_instance=RequestContext(request, processors=[custom_proc]))
 
     def view_2(request):
         # ...
-        return render_to_response('template2.html',
+        return render(request, 'template2.html',
             {'message': 'I am the second view.'},
             context_instance=RequestContext(request, processors=[custom_proc]))
 

--- a/chapter14.rst
+++ b/chapter14.rst
@@ -367,7 +367,7 @@ Here's a typical usage example::
 
         # If we didn't post, send the test cookie along with the login form.
         request.session.set_test_cookie()
-        return render_to_response('foo/login_form.html')
+        return render(request, 'foo/login_form.html')
 
 .. note::
 
@@ -837,7 +837,7 @@ or perhaps display an error message::
 
     def my_view(request):
         if not request.user.is_authenticated():
-            return render_to_response('myapp/login_error.html')
+            return render(request, 'myapp/login_error.html')
         # ...
 
 As a shortcut, you can use the convenient ``login_required`` decorator::
@@ -1031,7 +1031,7 @@ can use for this purpose, which we'll use in this example::
     from django import forms
     from django.contrib.auth.forms import UserCreationForm
     from django.http import HttpResponseRedirect
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
 
     def register(request):
         if request.method == 'POST':
@@ -1041,7 +1041,7 @@ can use for this purpose, which we'll use in this example::
                 return HttpResponseRedirect("/books/")
         else:
             form = UserCreationForm()
-        return render_to_response("registration/register.html", {
+        return render(request, "registration/register.html", {
             'form': form,
         })
 
@@ -1067,7 +1067,8 @@ Using Authentication Data in Templates
 --------------------------------------
 
 The current logged-in user and his or her permissions are made available in the
-template context when you use ``RequestContext`` (see Chapter 9).
+template context when you use the ``render()`` shortcut or explicitly use a
+``RequestContext`` (see Chapter 9).
 
 .. note::
 
@@ -1202,13 +1203,12 @@ playlist::
         request.user.message_set.create(
             message="Your playlist was added successfully."
         )
-        return render_to_response("playlists/create.html",
-            context_instance=RequestContext(request))
+        return render(request, "playlists/create.html")
 
-When you use ``RequestContext``, the current logged-in user and his or her
-messages are made available in the template context as the template variable
-``{{ messages }}``. Here's an example of template code that displays
-messages::
+When you use the ``render()`` shortcut or render a template with a
+``RequestContext``, the current logged-in user and his or her messages are made
+available in the template context as the template variable ``{{ messages }}``.
+Here's an example of template code that displays messages::
 
     {% if messages %}
     <ul>

--- a/chapter15.rst
+++ b/chapter15.rst
@@ -635,7 +635,7 @@ directly. This function sets, or adds to, the ``Vary header``. For example::
 
     def my_view(request):
         # ...
-        response = render_to_response('template_name', context)
+        response = render(request, 'template_name', context)
         patch_vary_headers(response, ['Cookie'])
         return response
 

--- a/chapter20.rst
+++ b/chapter20.rst
@@ -212,11 +212,11 @@ template system::
 
     # views.py
 
-    from django.shortcuts import render_to_response
+    from django.shortcuts import render
 
     def say_hello(request):
         name = request.GET.get('name', 'world')
-        return render_to_response('hello.html', {'name': name})
+        return render(request, 'hello.html', {'name': name})
 
     # hello.html
 


### PR DESCRIPTION
I've Replaced the render_to_response shortcut with render everywhere because
newer django code tends not to use render_to_response at all. I also
updated text where it refered to render_to_response arguments and the
use of RequestContext with render.
