### PR TITLE
Updated Chapter 2: Admonition 'Django and Python 3.0'

### DIFF
--- a/chapter02.rst
+++ b/chapter02.rst
@@ -34,15 +34,15 @@ features you might like to use in your applications. Plus, certain third-party
 Django add-ons that you might want to use might require a version newer than
 Python 2.5, so using a later version of Python keeps your options open.
 
-.. admonition:: Django and Python 3.0
+.. admonition:: Django and Python 3.x
 
-    At the time of writing, Python 3.0 had been released, but Django
-    only supported it experimentally. Python 3.0 introduced a
-    substantial number of backwards-incompatible changes to the
+    At the time of writing, Python 3.3 has been released, but Django
+    only supports it experimentally. This is because the Python 3.x series 
+    introduces a substantial number of backwards-incompatible changes to the
     language itself, and, as a result, many major Python libraries and
-    frameworks, including Django, had not yet caught up.
+    frameworks, including Django (as of version 1.4), have not yet caught up.
 
-    Django 1.5 will support Python 2.6, 2.7, and 3.2.  However,
+    Django 1.5 is slated to support Python 2.6, 2.7, and 3.2.  However,
     support for Python 3.2 is considered a "preview", which means the
     Django developers are not yet confident enough to promise
     stability in production.  For that, they suggest you wait until


### PR DESCRIPTION
Cheers.  Hope this passes muster.
My first time trying to contribute.

Updated a couple of points in the 'Django and Python 3.0' admonition
section:
1. Made it clear that the compatibility issues exist for the 3.x
series, not just 3.0.
1. Made it clear that Django as of version 1.4 doesn't support Python
   3.x
2. Changed the verb tense in a couple of places to made it fit the
   context more appropriately.
