### PR TITLE
.RST to .HTML link (generates 404 on production)

### DIFF
--- a/chapter01.rst
+++ b/chapter01.rst
@@ -363,4 +363,4 @@ What's Next
 In `Chapter 2`_, we'll get started with Django, covering installation and
 initial setup.
 
-.. _Chapter 2: chapter02.html/
+.. _Chapter 2: chapter02.html

--- a/chapter01.rst
+++ b/chapter01.rst
@@ -363,4 +363,4 @@ What's Next
 In `Chapter 2`_, we'll get started with Django, covering installation and
 initial setup.
 
-.. _Chapter 2: chapter02.rst/
+.. _Chapter 2: chapter02.html/

--- a/chapter02.rst
+++ b/chapter02.rst
@@ -502,4 +502,4 @@ What's Next?
 Now that you have everything installed and the development server running,
 you're ready to :doc: learn the basics `Chapter 3`_, of serving Web pages with Django.
 
-.. _Chapter 3: chapter03.rst/
+.. _Chapter 3: chapter03.html/

--- a/chapter02.rst
+++ b/chapter02.rst
@@ -502,4 +502,4 @@ What's Next?
 Now that you have everything installed and the development server running,
 you're ready to :doc: learn the basics `Chapter 3`_, of serving Web pages with Django.
 
-.. _Chapter 3: chapter03.html/
+.. _Chapter 3: chapter03.html

--- a/chapter03.rst
+++ b/chapter03.rst
@@ -913,4 +913,4 @@ Django ships with a simple yet powerful template engine that allows you to
 separate the design of the page from the underlying code. We'll dive into
 Django's template engine in the next chapter `Chapter 4`_.
 
-.. _Chapter 4: chapter04.html/
+.. _Chapter 4: chapter04.html

--- a/chapter03.rst
+++ b/chapter03.rst
@@ -913,4 +913,4 @@ Django ships with a simple yet powerful template engine that allows you to
 separate the design of the page from the underlying code. We'll dive into
 Django's template engine in the next chapter `Chapter 4`_.
 
-.. _Chapter 4: chapter04.rst/
+.. _Chapter 4: chapter04.html/


### PR DESCRIPTION
The links to the next chapters at the bottom of each chapter point to RST files, which generate a 404 in my browser (latest Chrome / Ubuntu 12.10)
