### PR TITLE
Update chapter06.rst

### DIFF
--- a/chapter06.rst
+++ b/chapter06.rst
@@ -240,7 +240,7 @@ Within the ``books`` directory (``mysite/books``), create a file called
 ``admin.py``, and type in the following lines of code::
 
     from django.contrib import admin
-    from mysite.books.models import Publisher, Author, Book
+    from books.models import Publisher, Author, Book
 
     admin.site.register(Publisher)
     admin.site.register(Author)


### PR DESCRIPTION
This line:
    from mysite.books.models import Publisher, Author, Book
Requires to be:
    from books.models import Publisher, Author, Book

If not, you get a 404 error saying that models does not exist under mysite.books
