### PR TITLE
Added ALLOWED_HOSTS change in 1.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 The Django Book
 ===============
 
+I will try to include the major changes in Django 1.5 compared to 1.3 untill then they changes can be found at https://docs.djangoproject.com/en/dev/releases/1.5/
+
 Welcome to the community edition of the Django Book!
 
 This book was originally published by Apress in 2009 and covered Django version 1.0. Since then it has languished and, in places, is **extremely out of date**. We are working on getting the book updated to cover Django versions 1.4, 1.5, and beyond. But we need your help, we’re making this book — warts and all — open source in the hopes that it will find love as a community project.

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,6 @@
 The Django Book
 ===============
 
-I will try to include the major changes in Django 1.5 compared to 1.4 untill then they changes can be found at https://docs.djangoproject.com/en/dev/releases/1.5/
-
 Welcome to the community edition of the Django Book!
 
 This book was originally published by Apress in 2009 and covered Django version 1.0. Since then it has languished and, in places, is **extremely out of date**. We are working on getting the book updated to cover Django versions 1.4, 1.5, and beyond. But we need your help, we’re making this book — warts and all — open source in the hopes that it will find love as a community project.

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 The Django Book
 ===============
 
-I will try to include the major changes in Django 1.5 compared to 1.3 untill then they changes can be found at https://docs.djangoproject.com/en/dev/releases/1.5/
+I will try to include the major changes in Django 1.5 compared to 1.4 untill then they changes can be found at https://docs.djangoproject.com/en/dev/releases/1.5/
 
 Welcome to the community edition of the Django Book!
 

--- a/chapter16.rst
+++ b/chapter16.rst
@@ -144,15 +144,15 @@ The Django sites framework provides a place for you to store the ``name`` and
 ``domain`` for each site in your Django project, which means you can reuse
 those values in a generic way.
 
-In Django 1.5 to protect from host poisoning attacks your domains must be 
-added in ALLOWED_HOSTS as shown below 
+In Django 1.5, to protect from host poisoning attacks, your domains must be 
+added in ALLOWED_HOSTS. For example::
 
-ALLOWED_HOSTS = [
-    '.ljworld.com', # Allow domain and subdomains
-    '.ljworld.com.', # Also allow FQDN and subdomains
-]
+    ALLOWED_HOSTS = [
+        '.ljworld.com', # Allow domain and subdomains
+        '.ljworld.com.', # Also allow FQDN and subdomains
+    ]
 
-Note: This is a compulsion while you are in production i.e when DEBUG: False
+Note: This is required while you are in production (i.e., when DEBUG is False)
 
 How to Use the Sites Framework
 ------------------------------

--- a/chapter16.rst
+++ b/chapter16.rst
@@ -144,6 +144,16 @@ The Django sites framework provides a place for you to store the ``name`` and
 ``domain`` for each site in your Django project, which means you can reuse
 those values in a generic way.
 
+In Django 1.5 to protect from host poisoning attacks your domains must be 
+added in ALLOWED_HOSTS as shown below 
+
+ALLOWED_HOSTS = [
+    '.ljworld.com', # Allow domain and subdomains
+    '.ljworld.com.', # Also allow FQDN and subdomains
+]
+
+Note: This is a compulsion while you are in production i.e when DEBUG: False
+
 How to Use the Sites Framework
 ------------------------------
 


### PR DESCRIPTION
Django 1.5 does not allow a website if it is not allowed so the domains must be added in-order to protect from host poisoning attacks
