### PR TITLE
Removed "mysite" from the "Adding Your Models to the Admin Site" section

### DIFF
--- a/chapter06.rst
+++ b/chapter06.rst
@@ -240,7 +240,7 @@ Within the ``books`` directory (``mysite/books``), create a file called
 ``admin.py``, and type in the following lines of code::
 
     from django.contrib import admin
-    from mysite.books.models import Publisher, Author, Book
+    from books.models import Publisher, Author, Book
 
     admin.site.register(Publisher)
     admin.site.register(Author)


### PR DESCRIPTION
Within the "Adding Your Models to the Admin Site" section, the code reads
from django.contrib import admin
from mysite.books.models import Publisher, Author, Book
I removed mysite from this statement to read
from django.contrib import admin
from books.models import Publisher, Author, Book
This is due to the fact that "mysite" caused an import error that was corrected by removing "mysite".
