### PR TITLE
Possible Import error corrected in code

### DIFF
--- a/chapter06.rst
+++ b/chapter06.rst
@@ -240,7 +240,7 @@ Within the ``books`` directory (``mysite/books``), create a file called
 ``admin.py``, and type in the following lines of code::
 
     from django.contrib import admin
-    from mysite.books.models import Publisher, Author, Book
+    from books.models import Publisher, Author, Book
 
     admin.site.register(Publisher)
     admin.site.register(Author)


### PR DESCRIPTION
At line 243 which reads as :
from mysite.books.models import Publisher, Author, Book

Django 1.4.3 gives an import error. But when written as :
from books.models import Publisher, Author, Book
Works successfully.
