### PR TITLE
Chapter 6 on "Adding Your Models to the Admin Site

### DIFF
--- a/chapter06.rst
+++ b/chapter06.rst
@@ -240,7 +240,7 @@ Within the ``books`` directory (``mysite/books``), create a file called
 ``admin.py``, and type in the following lines of code::
 
     from django.contrib import admin
-    from mysite.books.models import Publisher, Author, Book
+    from models import Publisher, Author, Book
 
     admin.site.register(Publisher)
     admin.site.register(Author)


### PR DESCRIPTION
There's a incorrect import statement on chapter 6 in the section that says "Adding Your Models to the Admin Site". I've been stuck for several minutes believing that I've hit a brick wall, but it turns out that on line 2 in "mysite/books/admin.py" should only say "from models import" instead of "from mysite.books.models import"
