### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter01.rst
+++ b/chapter01.rst
@@ -363,4 +363,4 @@ What's Next
 In `Chapter 2`_, we'll get started with Django, covering installation and
 initial setup.
 
-.. _Chapter 2: chapter02.html
+.. _Chapter 2: chapter02.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 2. The link is actually jacobian/djangobook.com/blob/master/chapter02.rst not ../chapter02.html.
