### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter02.rst
+++ b/chapter02.rst
@@ -502,4 +502,4 @@ What's Next?
 Now that you have everything installed and the development server running,
 you're ready to :doc: learn the basics `Chapter 3`_, of serving Web pages with Django.
 
-.. _Chapter 3: chapter03.html
+.. _Chapter 3: chapter03.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 3. The link is actually jacobian/djangobook.com/blob/master/chapter03.rst not ../chapter03.html.
