### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter04.rst
+++ b/chapter04.rst
@@ -1613,4 +1613,4 @@ stored in a relational database. This allows a clean separation of data and logi
 The next chapter `Chapter 5`_ covers the tools Django gives you to
 interact with a database.
 
-.. _Chapter 5: chapter05.html
+.. _Chapter 5: chapter05.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 5. The link is actually jacobian/djangobook.com/blob/master/chapter05.rst not ../chapter05.html.
