### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter06.rst
+++ b/chapter06.rst
@@ -989,4 +989,4 @@ So far we've created a few models and configured a top-notch interface for
 editing data. In the next chapter `Chapter 7`_, we'll move on to the real "meat and potatoes"
 of Web development: form creation and processing.
 
-.. _Chapter 7: chapter07.html
+.. _Chapter 7: chapter07.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 7. The link is actually jacobian/djangobook.com/blob/master/chapter07.rst not ../chapter07.html.
