### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter07.rst
+++ b/chapter07.rst
@@ -1293,4 +1293,4 @@ missing pieces as you need them.
 We'll start in `Chapter 8`_, by doubling back and taking a closer look at views
 and URLconfs (introduced first in `chapter03`).
 
-.. _chapter 8: chapter08.html
+.. _chapter 8: chapter08.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 8. The link is actually jacobian/djangobook.com/blob/master/chapter08.rst not ../chapter08.html.
