### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter08.rst
+++ b/chapter08.rst
@@ -10,7 +10,7 @@ In `Chapter 3`_, we explained the basics of Django view functions and URLconfs.
 This chapter goes into more detail about advanced functionality in those two
 pieces of the framework.
 
-.. _Chapter 3: chapter03.html
+.. _Chapter 3: chapter03.rst
 
 URLconf Tricks
 ==============
@@ -1130,4 +1130,4 @@ This chapter has provided many advanced tips and tricks for views and URLconfs.
 Next, in `Chapter 9`_, we'll give this advanced treatment to Django's template
 system.
 
-.. _Chapter 9: chapter09.html
+.. _Chapter 9: chapter09.rst


### PR DESCRIPTION
Fixed the link at the beginning of the page that links to Chapter 3 and at the end of the page that links to Chapter 9. The links are actually jacobian/djangobook.com/blob/master/chapter03.rst and jacobian/djangobook.com/blob/master/chapter09.rst not ../chapter03.html and ../chapter09.html, respectively.
