### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter09.rst
+++ b/chapter09.rst
@@ -1294,4 +1294,4 @@ What's Next
 Continuing this section's theme of advanced topics, the `next chapter`_ covers
 advanced usage of Django models.
 
-.. _next chapter: chapter10.html
+.. _next chapter: chapter10.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 10. The link is actually jacobian/djangobook.com/blob/master/chapter10.rst not ../chapter10.html.
