### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter10.rst
+++ b/chapter10.rst
@@ -598,4 +598,4 @@ What's Next?
 In the `next chapter`_, we'll show you Django's "generic views" framework, which
 lets you save time in building Web sites that follow common patterns.
 
-.. _next chapter: chapter11.html
+.. _next chapter: chapter11.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 11. The link is actually jacobian/djangobook.com/blob/master/chapter11.rst not ../chapter11.html.
