### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter11.rst
+++ b/chapter11.rst
@@ -518,4 +518,4 @@ recommended reading if you want to get the most out of this powerful feature.
 This concludes the section of this book devoted to "advanced usage." In the
 `next chapter`_, we cover deployment of Django applications.
 
-.. _next chapter: chapter12.html
+.. _next chapter: chapter12.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 12. The link is actually jacobian/djangobook.com/blob/master/chapter12.rst not ../chapter12.html.
