### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter12.rst
+++ b/chapter12.rst
@@ -1073,7 +1073,7 @@ Of course, selecting memcached does you no good if you don't actually use it.
 framework, and use it everywhere possible. Aggressive, preemptive caching is
 usually the only thing that will keep a site up under major traffic.
 
-.. _Chapter 15: chapter15.html
+.. _Chapter 15: chapter15.rst
 
 Join the Conversation
 ---------------------


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 15. The link is actually jacobian/djangobook.com/blob/master/chapter15.rst not ../chapter15.html.
