### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter13.rst
+++ b/chapter13.rst
@@ -986,4 +986,4 @@ Next, we'll continue to dig deeper into the built-in tools Django gives you.
 `Chapter 14`_ looks at all the tools you need to provide user-customized
 sites: sessions, users, and authentication.
 
-.. _Chapter 14: chapter14.html
+.. _Chapter 14: chapter14.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 14. The link is actually jacobian/djangobook.com/blob/master/chapter14.rst not ../chapter14.html.
