### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter14.rst
+++ b/chapter14.rst
@@ -1236,4 +1236,4 @@ available.
 In the `next chapter`_, we'll take a look at Django's caching infrastructure,
 which is a convenient way to improve the performance of your application.
 
-.. _next chapter: chapter15.html
+.. _next chapter: chapter15.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 15. The link is actually jacobian/djangobook.com/blob/master/chapter15.rst not ../chapter15.html.
