### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter15.rst
+++ b/chapter15.rst
@@ -760,4 +760,4 @@ make your life easier. We've already covered a few of these: the admin site
 (Chapter 6) and the session/user framework (Chapter 14). The `next chapter`_
 covers more of the "contributed" subframeworks.
 
-.. _next chapter: chapter16.html
+.. _next chapter: chapter16.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 16. The link is actually jacobian/djangobook.com/blob/master/chapter16.rst not ../chapter16.html.
