### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter16.rst
+++ b/chapter16.rst
@@ -946,4 +946,4 @@ and/or after every request and can modify requests and responses at will, to
 extend the framework. In the `next chapter`_, we'll discuss Django's built-in
 middleware and explain how you can write your own.
 
-.. _next chapter: chapter17.html
+.. _next chapter: chapter17.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 17. The link is actually jacobian/djangobook.com/blob/master/chapter17.rst not ../chapter17.html.
