### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter17.rst
+++ b/chapter17.rst
@@ -389,4 +389,4 @@ Web developers and database-schema designers don't always have the luxury of
 starting from scratch. In the `next chapter`_, we'll cover how to integrate with
 legacy systems, such as database schemas you've inherited from the 1980s.
 
-.. _next chapter: chapter18.html
+.. _next chapter: chapter18.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 18. The link is actually jacobian/djangobook.com/blob/master/chapter18.rst not ../chapter18.html.
