### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter18.rst
+++ b/chapter18.rst
@@ -299,4 +299,4 @@ framework (and the hard work of Django's volunteer translators). The
 `next chapter`_ explains how to use this framework to provide localized Django
 sites.
 
-.. _next chapter: chapter19.html
+.. _next chapter: chapter19.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 19. The link is actually jacobian/djangobook.com/blob/master/chapter19.rst not ../chapter19.html.
