### PR TITLE
Changed .html to .rst to fix link

### DIFF
--- a/chapter19.rst
+++ b/chapter19.rst
@@ -940,4 +940,4 @@ What's Next?
 The `final chapter`_ focuses on security -- how you can help secure your sites and
 your users from malicious attackers.
 
-.. _final chapter: chapter20.html
+.. _final chapter: chapter20.rst


### PR DESCRIPTION
Fixed the link at the end of the page that links to Chapter 20. The link is actually jacobian/djangobook.com/blob/master/chapter20.rst not ../chapter20.html.
