### PR TITLE
Changed .html to .rst to fix links

### DIFF
--- a/chapter20.rst
+++ b/chapter20.rst
@@ -516,5 +516,5 @@ your Django projects.
 We wish you the best of luck in running your Django site, whether it's a little
 toy for you and a few friends, or the next Google.
 
-.. _Chapter 14: chapter14.html
-.. _Chapter 16: chapter16.html
+.. _Chapter 14: chapter14.rst
+.. _Chapter 16: chapter16.rst


### PR DESCRIPTION
Fixed the links at the end of the page that link to Chapter 14 and Chapter 16. The links are actually jacobian/djangobook.com/blob/master/chapter14.rst and jacobian/djangobook.com/blob/master/chapter16.rst not ../chapter14.html and ../chapter16.html, respectively.
